### PR TITLE
bug fix: Each child in a list should have a unique "key" prop.

### DIFF
--- a/svgo.config.mjs
+++ b/svgo.config.mjs
@@ -24,5 +24,18 @@ export default {
         };
       },
     },
+    {
+      name: "addKeyAttr",
+      description: "Add key attribute",
+      fn: () => {
+        return {
+          element: {
+            enter: (node) => {
+              node.attributes.key = Math.random().toString(36).substring(2, 9);
+            },
+          },
+        };
+      },
+    },
   ],
 };


### PR DESCRIPTION
Hi @xandemon , I encountered a problem when using Icon: When using it in React, an error will be reported in the console: `Each child in a list should have a unique "key" prop`. 

The reason for this problem is: the return value in the `createDeveloperIcon` function contains `createELement`, and the children parameter of the `createELement` function requires the `key` attribute.
Based on this, I made some changes. This is my first PR. If this change is feasible, or you are willing for me to participate, we can discuss the solution again!