### PR TITLE
docs(readme): add users info

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@main

--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -13,4 +13,4 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: gouravkhunger/dependents.info@main
+      - uses: gouravkhunger/dependents.info@0.1.3

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@
     <a href="https://github.com/xandemon/developer-icons/stargazers" target="_blank">
       <img src="https://img.shields.io/github/stars/xandemon/developer-icons?logo=github&logoColor=fff&label=Stars&labelColor=333&color=FFD700&style=flat" alt="Developer-Icons GitHub Stars" style="height:24px">
     </a>
+    <a href="https://dependents.info/xandemon/developer-icons" target="_blank">
+      <img src="https://dependents.info/xandemon/developer-icons/badge" alt="Developer-Icons GitHub Network Dependents" style="height:24px" />
+    </a>
     <a href="https://github.com/xandemon/developer-icons/stargazers" target="_blank">
       <img src="https://img.shields.io/github/forks/xandemon/developer-icons?logo=github&logoColor=fff&label=Forks&labelColor=333&color=148ACF&style=flat" alt="Developer-Icons GitHub Forks" style="height:24px">
     </a>
@@ -64,6 +67,12 @@
 </p>
 
 Welcome to **`developer-icons`**—a curated set of high-quality, customizable tech icons built for developers and designers. Fully compatible with TypeScript, ideal for React and Next.js, or downloadable from our [official website](https://xandemon.github.io/developer-icons/icons/All "Developer Icons Website") for design projects.
+
+## 🧑‍💻 Used by
+
+<a href="https://dependents.info/xandemon/developer-icons" target="_blank">
+  <img src="https://dependents.info/xandemon/developer-icons/image" alt="Developer-Icons GitHub Users" />
+</a>
 
 ## 🚀 Tech Stack
 


### PR DESCRIPTION
Hi there!

Thank you for this awesome project! This PR adds a relevant auto-updated shields.io style network dependents badge and the image in the `README.md` file to showcase its impact.

I've created this using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built some time ago. It also creates an image preview of the users in the readme.

Here's how they would look for your repository:

<img width="703" alt="image" src="https://github.com/user-attachments/assets/f1d2bbf4-f2dc-4635-9038-f8a4f0107731" />

Please feel free to close the PR if you don't want to have this!