### PR TITLE
docs(README.md): Add contributors information section in README.md (#72)

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,44 @@
+name: Update Contributors in README
+
+on:
+  # Run on push to main (or your default branch)
+  # You can also add `workflow_dispatch` to trigger it manually
+  push:
+    branches:
+      - main # Change to your default branch (e.g., master)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  update-contributors:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to commit changes to README.md
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate Contributors List
+        uses: jaywcjlove/github-action-contributors@main
+        id: contributors_list
+        with:
+          # Optional: filter out bots
+          filter-author: (renovate\[bot\]|renovate-bot|dependabot\[bot\])
+          # Output as HTML list
+          output: "htmlList"
+          # Adjust avatar size (default is 24)
+          avatarSize: 48
+          # Set the delimiter for where to inject the list in your README
+          openDelimiter: "<!--CONTRIBUTORS-->"
+          closeDelimiter: "<!--CONTRIBUTORS-END-->"
+          # Hide names, only show avatars
+          hideName: true
+
+      - name: Update README.md
+        uses: jaywcjlove/github-action-modify-file-content@main
+        with:
+          path: README.md
+          body: "${{ steps.contributors_list.outputs.htmlList }}"

--- a/README.md
+++ b/README.md
@@ -137,6 +137,19 @@ export const YourReactComponent = () => {
 
 In this example, we import `HtmlIcon` and `JavascriptIcon` from the `developer-icons` package and use them within a React component. You can customize the icons by adjusting their `size`, `color`, `style`, and other properties.
 
+## 🤝 Contributors
+<style>
+  #contributor a img {
+    border-radius: 100%
+  }
+</style>
+
+<div id="contributor">
+<!--CONTRIBUTORS-->
+<!--CONTRIBUTORS-END-->
+</div>
+
+
 ## 🤝 Contributing
 
 We welcome contributions of all kinds, whether you're looking to add new icons, improve existing ones, or enhance the overall project. To get started, refer to our [Contributing Guidelines](https://xandemon.github.io/developer-icons/docs/contributing).

--- a/README.md
+++ b/README.md
@@ -138,11 +138,6 @@ export const YourReactComponent = () => {
 In this example, we import `HtmlIcon` and `JavascriptIcon` from the `developer-icons` package and use them within a React component. You can customize the icons by adjusting their `size`, `color`, `style`, and other properties.
 
 ## 🤝 Contributors
-<style>
-  #contributor a img {
-    border-radius: 100%
-  }
-</style>
 
 <div id="contributor">
 <!--CONTRIBUTORS-->


### PR DESCRIPTION
I have added the contributors section in the readme. it will automaticaaly write the code for contributors. And return this type of data. I have removed css because it will not work in github. if you want it you can tell us. I will try to add it.

Issue: #72 

![Capture](https://github.com/user-attachments/assets/49b77e91-a85d-4ccb-9a1a-251182441d97)
